### PR TITLE
[FEATURE] forgotten password mail + reset password

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party = flask,flask_jwt_extended,flask_mongoengine,flask_restful,marshmallow,mongoengine,pytest,werkzeug
+known_third_party = flask,flask_jwt_extended,flask_mail,flask_mongoengine,flask_restful,marshmallow,mongoengine,pytest,werkzeug

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -35,6 +35,7 @@ class MongoEngineEncoder(json.JSONEncoder):
 
 def create_app(config_name="dev"):
     from app.models import db
+    from app.common.mail import mail
 
     app = Flask(__name__)
 
@@ -44,14 +45,16 @@ def create_app(config_name="dev"):
     # Setup DB
     db.init_app(app)
 
-    # Setup JWT-extended
+    # Setup Flask-JWT-extended
     jwt = JWTManager(app)
     setup_jwt(jwt)
     jwt.init_app(app)
 
-    api = Api(app)
+    # Setup Flask-Mail
+    mail.init_app(app)
 
-    # Routing
+    # Routing URLs
+    api = Api(app)
     for urlpattern in urlpatterns:
         api.add_resource(
             urlpattern["resource"], urlpattern["url"], endpoint=urlpattern["endpoint"]

--- a/app/api/v1/user_resources.py
+++ b/app/api/v1/user_resources.py
@@ -2,7 +2,12 @@ from flask import request
 from flask_jwt_extended import jwt_required
 from flask_restful import Resource
 
-from app.services.user_services import login, logout
+from app.services.user_services import (
+    forgotten_password,
+    login,
+    logout,
+    update_password,
+)
 
 
 class LoginResource(Resource):
@@ -15,3 +20,14 @@ class LogoutResource(Resource):
     @jwt_required
     def delete(self):
         return logout()
+
+
+class ForgottenPasswordResource(Resource):
+    def post(self):
+        data = request.data
+        return forgotten_password(data)
+
+
+class ResetPasswordResource(Resource):
+    def post(self):
+        return update_password(params=request.args, data=request.data)

--- a/app/common/errors.py
+++ b/app/common/errors.py
@@ -2,7 +2,6 @@ from enum import Enum
 
 
 class ErrorType(Enum):
-    LOGIN_ERROR = "Login Error"
     AUTHORIZATION_ERROR = "Authorization Error"
     INVALID_DATA_ERROR = "Invalid Data Error"
     BAD_REQUEST_ERROR = "Bad Request Error"
@@ -19,14 +18,6 @@ class BaseError(object):
         return self.content, self.error_code
 
 
-# Login errors
-UNSUCCESSFUL_LOGIN_EMAIL_NOT_FOUND = BaseError(
-    ErrorType.LOGIN_ERROR, "Email not found", 404
-)
-UNSUCCESSFUL_LOGIN_WRONG_PASSWORD = BaseError(
-    ErrorType.LOGIN_ERROR, "Incorrect password", 400
-)
-
 # Authorization errors
 UNAUTHORIZED_TOKEN = BaseError(
     ErrorType.AUTHORIZATION_ERROR, "Missing access token. You must login first.", 401
@@ -41,6 +32,10 @@ REVOKED_TOKEN = BaseError(
 PERMISSION_DENIED = BaseError(ErrorType.AUTHORIZATION_ERROR, "Permission Denied.", 403)
 
 # Invalid data errors
+EMAIL_NOT_FOUND_ERROR = BaseError(ErrorType.INVALID_DATA_ERROR, "Email not found", 404)
+INVALID_PASSWORD_ERROR = BaseError(
+    ErrorType.INVALID_DATA_ERROR, "Incorrect password", 400
+)
 INVALID_DATA_ERROR = BaseError(
     ErrorType.INVALID_DATA_ERROR, "Error while loading data.", 400
 )

--- a/app/common/mail/__init__.py
+++ b/app/common/mail/__init__.py
@@ -1,0 +1,3 @@
+from flask_mail import Mail
+
+mail = Mail()

--- a/app/common/mail/mail_services.py
+++ b/app/common/mail/mail_services.py
@@ -1,0 +1,22 @@
+from flask import render_template
+from flask_mail import Message
+
+from app.common.mail import mail
+from app.common.mail.schemas import password_reset_schema
+
+
+def send_reset_password_mail(recipient: str, reset_url: str) -> None:
+    msg = Message(
+        subject=password_reset_schema["subject"],
+        recipients=[recipient],
+        body=render_template(
+            password_reset_schema["body_template"], reset_url=reset_url
+        ),
+        html=render_template(
+            password_reset_schema["html_template"], reset_url=reset_url
+        ),
+    )
+    # TODO : Move that to a thread as it takes quite some times (Maybe use Redis ?)
+    mail.send(msg)
+
+    return

--- a/app/common/mail/schemas.py
+++ b/app/common/mail/schemas.py
@@ -1,0 +1,5 @@
+password_reset_schema = {
+    "subject": "CAPLC : Réinitialise ton mot de passe !",
+    "html_template": "mail/reset_password.html",
+    "body_template": "mail/reset_password.txt",
+}

--- a/app/config.py
+++ b/app/config.py
@@ -2,21 +2,36 @@ import datetime
 import os
 
 
-# TODO : Add env file
 class Config:
-    SECRET_KEY = os.getenv("CAPLC_SECRET_KEY", "my_precious_secret_key")
+    # Flask
+    SECRET_KEY = os.getenv("SECRET_KEY", "my_precious_secret_key")
     JWT_SECRET_KEY = SECRET_KEY
     DEBUG = False
+    PREFERRED_URL_SCHEME = os.getenv("PREFERRED_URL_SCHEME", "")
+    # Flask-resful
     RESTFUL_JSON = dict(indent=2, sort_keys=False, separators=(", ", ": "))
+
+    # Flask-JWT-Extended
     JWT_BLACKLIST_ENABLED = True
     JWT_BLACKLIST_TOKEN_CHECKS = ["access"]
     JWT_ACCESS_TOKEN_EXPIRES = datetime.timedelta(days=2)
-    MONGODB_USERNAME = os.getenv("CAPLC_MONGODB_USERNAME")
-    MONGODB_PASSWORD = os.getenv("CAPLC_MONGODB_PASSWORD")
-    MONGODB_DB = os.getenv("CAPLC_MONGODB_DB")
-    MONGODB_HOST = os.getenv("CAPLC_MONGODB_HOST")
-    MONGODB_PORT = int(os.getenv("CAPLC_MONGODB_PORT"))
-    MONGODB_AUTHENTICATION_SOURCE = "test"
+
+    # Flask-MongoEngine
+    MONGODB_USERNAME = os.getenv("MONGODB_USERNAME")
+    MONGODB_PASSWORD = os.getenv("MONGODB_PASSWORD")
+    MONGODB_DB = os.getenv("MONGODB_DB")
+    MONGODB_HOST = os.getenv("MONGODB_HOST")
+    MONGODB_PORT = int(os.getenv("MONGODB_PORT"))
+
+    # Flask Mail
+    MAIL_SERVER = os.getenv("MAIL_SERVER")
+    MAIL_PORT = int(os.getenv("MAIL_PORT"))
+    MAIL_USE_TLS = bool(int(os.getenv("MAIL_USE_TLS", 0)))
+    MAIL_USE_SSL = bool(int(os.getenv("MAIL_USE_SSL", 0)))
+    MAIL_USERNAME = os.getenv("MAIL_USERNAME")
+    MAIL_PASSWORD = os.getenv("MAIL_PASSWORD")
+    MAIL_DEFAULT_SENDER = os.getenv("MAIL_DEFAULT_SENDER") or MAIL_USERNAME
+    MAIL_SUPPRESS_SEND = True  # Prevent from sending email
 
 
 class DevelopmentConfig(Config):
@@ -31,6 +46,7 @@ class TestingConfig(Config):
 
 class ProductionConfig(Config):
     DEBUG = False
+    MAIL_SUPPRESS_SEND = False
 
 
 config_by_name = dict(dev=DevelopmentConfig, test=TestingConfig, prod=ProductionConfig)

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -8,6 +8,16 @@ class LoginSchema(CustomSchema):
     password = fields.Str(required=True)
 
 
+class ForgottenPasswordSchema(CustomSchema):
+    email = fields.Str(required=True)
+
+
+class NewPasswordSchema(CustomSchema):
+    password = fields.Str(
+        required=True, validate=validate.Length(min=8), load_only=True
+    )
+
+
 class UserSchema(CustomSchema):
     firstName = fields.Str(required=True, validate=validate.Length(min=1, max=64))
     lastName = fields.Str(required=True, validate=validate.Length(min=1, max=64))

--- a/app/templates/mail/reset_password.html
+++ b/app/templates/mail/reset_password.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Réinitialise ton mot de passe.</title>
+</head>
+<body>
+<p>Hello,</p>
+<p>Pour réinitialiser ton mot de passe, clique sur ce lien : <a href="{{ reset_url }}">Réinitialisation de mot de passe.</a></p>
+<p>Ciao.</p>
+</body>
+</html>

--- a/app/templates/mail/reset_password.txt
+++ b/app/templates/mail/reset_password.txt
@@ -1,0 +1,3 @@
+Hello
+Pour réinitialiser ton mot de passe, clique sur ce lien : {{ reset_url }}
+Ciao

--- a/app/urls.py
+++ b/app/urls.py
@@ -1,11 +1,26 @@
 from app.api.ping import PingResource
 from app.api.v1.moderator_resources import ModeratorListResource, ModeratorResource
-from app.api.v1.user_resources import LoginResource, LogoutResource
+from app.api.v1.user_resources import (
+    ForgottenPasswordResource,
+    LoginResource,
+    LogoutResource,
+    ResetPasswordResource,
+)
 
 urlpatterns = [
     dict(resource=PingResource, url="/api/ping", endpoint="ping"),
     dict(resource=LoginResource, url="/api/v1/login", endpoint="login"),
     dict(resource=LogoutResource, url="/api/v1/logout", endpoint="logout"),
+    dict(
+        resource=ForgottenPasswordResource,
+        url="/api/v1/forgotten_password",
+        endpoint="forgotten-password",
+    ),
+    dict(
+        resource=ResetPasswordResource,
+        url="/api/v1/reset_password",
+        endpoint="reset-password",
+    ),
     dict(
         resource=ModeratorListResource,
         url="/api/v1/moderators",

--- a/docker/docker-compose.mongo_only.yml
+++ b/docker/docker-compose.mongo_only.yml
@@ -8,7 +8,7 @@ services:
             MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME:?err}
             MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD:?err}
         ports:
-            - ${CAPLC_MONGODB_PORT:?err}:27017
+            - ${MONGODB_PORT:?err}:27017
         volumes:
             - ./mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
         command: mongod --auth

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 aniso8601==8.0.0
 attrs==19.3.0
+blinker==1.4
 click==7.1.1
 Flask==1.1.1
 Flask-JWT-Extended==3.24.1
+Flask-Mail==0.9.1
 flask-mongoengine==0.9.5
 Flask-RESTful==0.3.8
 Flask-WTF==0.14.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from mongoengine import get_db
 from werkzeug.security import generate_password_hash
 
 from app import create_app
+from app.common.mail import mail as _mail
 from app.models import db as _db
 from app.models.user_model import UserModel
 
@@ -44,6 +45,13 @@ def db(app, request):
 
     request.addfinalizer(teardown)
     return _db
+
+
+@pytest.fixture(scope="session")
+def mail(app):
+    """A test client for the app."""
+    _mail.app = app
+    return _mail
 
 
 # TODO : Check if the following two functions can be less repetitive

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -3,16 +3,20 @@ import json
 import time
 
 from flask_jwt_extended import create_access_token
+from werkzeug.security import check_password_hash
 
 from app.common.errors import (
+    EMAIL_NOT_FOUND_ERROR,
     EXPIRED_TOKEN,
+    INVALID_DATA_ERROR,
+    INVALID_PASSWORD_ERROR,
     INVALID_TOKEN,
     PERMISSION_DENIED,
     REVOKED_TOKEN,
     UNAUTHORIZED_TOKEN,
-    UNSUCCESSFUL_LOGIN_EMAIL_NOT_FOUND,
-    UNSUCCESSFUL_LOGIN_WRONG_PASSWORD,
 )
+from app.common.mail.schemas import password_reset_schema
+from app.models.user_model import UserModel
 
 
 def _get_authorization_header(token):
@@ -34,8 +38,8 @@ def test_unsuccessful_login_wrong_email(client, init_admin):
 
     response = client.post("api/v1/login", data=json.dumps(data))
     response_data, status_code = json.loads(response.data), response.status_code
-    assert status_code == UNSUCCESSFUL_LOGIN_EMAIL_NOT_FOUND.error_code
-    assert response_data == UNSUCCESSFUL_LOGIN_EMAIL_NOT_FOUND.content
+    assert status_code == EMAIL_NOT_FOUND_ERROR.error_code
+    assert response_data == EMAIL_NOT_FOUND_ERROR.content
 
 
 def test_unsuccessful_login_wrong_password(client, init_admin):
@@ -43,8 +47,8 @@ def test_unsuccessful_login_wrong_password(client, init_admin):
 
     response = client.post("api/v1/login", data=json.dumps(data))
     response_data, status_code = json.loads(response.data), response.status_code
-    assert response_data == UNSUCCESSFUL_LOGIN_WRONG_PASSWORD.content
-    assert status_code == UNSUCCESSFUL_LOGIN_WRONG_PASSWORD.error_code
+    assert response_data == INVALID_PASSWORD_ERROR.content
+    assert status_code == INVALID_PASSWORD_ERROR.error_code
 
 
 def test_succesful_logout(client, auth, init_admin):
@@ -82,7 +86,6 @@ def test_with_expired_token(client, db):
 
 # Request with invalid token
 def test_with_invalid_token(client, db):
-
     response = client.delete(
         "api/v1/logout", headers=_get_authorization_header("Invalid token")
     )
@@ -121,3 +124,69 @@ def test_good_access_level(client, auth, init_moderator):
     response = client.get("/api/v1/moderators", headers=headers)
 
     assert response.status_code == 200
+
+
+def test_forgotten_password_mail_sent(client, mail, init_moderator):
+    with mail.record_messages() as outbox:
+        data = {"email": init_moderator.email}
+        response = client.post("/api/v1/forgotten_password", data=json.dumps(data))
+        assert response.status_code == 204
+        assert len(outbox) == 1
+        assert outbox[0].subject == password_reset_schema["subject"]
+
+
+def test_forgotten_password_invalid_data(client, init_moderator):
+    data = {"email": "nonexistingemail@test.com"}
+
+    response = client.post("/api/v1/forgotten_password", data=json.dumps(data))
+    response_data, status_code = json.loads(response.data), response.status_code
+
+    assert status_code == EMAIL_NOT_FOUND_ERROR.error_code
+    assert response_data == EMAIL_NOT_FOUND_ERROR.content
+
+
+def test_reset_password(client, init_moderator):
+    data = {"password": "new_password"}
+
+    token = init_moderator.send_reset_password_mail()
+
+    response = client.post(
+        "/api/v1/reset_password",
+        data=json.dumps(data),
+        query_string={"access_token": token},
+    )
+    init_moderator = UserModel.find_by_id(user_id=init_moderator.id)
+    assert response.status_code == 204
+    assert check_password_hash(pwhash=init_moderator.password, password="new_password")
+
+
+def test_reset_password_invalid_token(client, init_moderator):
+    data = {"password": "new_d"}  # Password too short
+
+    init_moderator.send_reset_password_mail()
+
+    response = client.post(
+        "/api/v1/reset_password",
+        data=json.dumps(data),
+        query_string={"access_token": "invalid token"},
+    )
+    response_data, status_code = json.loads(response.data), response.status_code
+
+    assert status_code == INVALID_TOKEN.error_code
+    assert response_data == INVALID_TOKEN.content
+
+
+def test_reset_password_invalid_new_password(client, init_moderator):
+    data = {"password": "new_d"}  # Password too short
+
+    token = init_moderator.send_reset_password_mail()
+
+    response = client.post(
+        "/api/v1/reset_password",
+        data=json.dumps(data),
+        query_string={"access_token": token},
+    )
+    response_data, status_code = json.loads(response.data), response.status_code
+
+    assert status_code == INVALID_DATA_ERROR.error_code
+    assert response_data == INVALID_DATA_ERROR.content

--- a/venv/env.exemple
+++ b/venv/env.exemple
@@ -1,12 +1,24 @@
 # Flask
 FLASK_ENV=development
 FLASK_APP="app:create_app('dev')"
-CAPLC_SECRET_KEY=my_precious_secret_key
-CAPLC_MONGODB_USERNAME=caplc_user
-CAPLC_MONGODB_PASSWORD=password123
-CAPLC_MONGODB_DB=caplcDB
-CAPLC_MONGODB_HOST=127.0.0.1
-CAPLC_MONGODB_PORT=27017
+SECRET_KEY=my_precious_secret_key
+PREFERRED_URL_SCHEME=http://example.com
+
+# Flask-MongoEngine
+MONGODB_USERNAME=caplc_user
+MONGODB_PASSWORD=password123
+MONGODB_DB=caplcDB
+MONGODB_HOST=127.0.0.1
+MONGODB_PORT=27017
+
+# Flask-Mail
+MAIL_SERVER=localhost
+MAIL_PORT=25
+MAIL_USE_TLS=0
+MAIL_USE_SSL=0
+MAIL_USERNAME=example@test.com
+MAIL_PASSWORD=mypassword
+MAIL_DEFAULT_SENDER=example@test.com
 
 # Mongo
 MONGO_INITDB_ROOT_USERNAME=mongocaplc


### PR DESCRIPTION
Adding feature to handle password reset.
Created two routes : 
- POST api/v1/forgotten_password 
- POST api/v1/reset_password

The first one expect an email in the body, and will send an email to the user with a link where he can reset his password. Within the link, an access token is passed so that only people having received the mail can use the second route.

The second route expect an access token in the URL parameter + new password in the body.
It checks the validity of the access token and change the password of the user accordingly.

Additional infos : 
- Added package Flask-Mail
- Revamp Config variables name in env files