### PR TITLE
Adding CLI command importcsv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ venv/*.env
 
 # Pycharm stuff
 .idea/
+
+# CSV files
+ressources/csv/*.csv

--- a/ressources/csv/action_cards.csv.example
+++ b/ressources/csv/action_cards.csv.example
@@ -1,0 +1,4 @@
+number,title,category,type,key,sector,cost
+1,action_card_title_1,action_card_category_1,action_card_type_1,action_card_key_1,action_card_sector_1,1
+2,action_card_title_2,action_card_category_2,action_card_type_2,action_card_key_2,action_card_sector_2,2
+3,action_card_title_3,action_card_category_3,action_card_type_3,action_card_key_3,action_card_sector_3,3

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,13 @@
+import os
+from csv import DictReader
+
 from werkzeug.security import check_password_hash
 
-from app.cli import create_admin
+from app.cli import create_admin, importcsv
+from app.models.action_card_model import ActionCardModel
 from app.models.user_model import UserModel
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 def test_create_admin(cli_runner, db, request):
@@ -47,3 +53,83 @@ def test_create_admin_already_existing(cli_runner, init_admin):
 
     result = cli_runner.invoke(create_admin, input=input_stream)
     assert "Issue when creating admin." in result.output
+
+
+def test_importcsv_with_model_not_enabled(cli_runner):
+    collection = "users"
+    csv_file = "{}/ressources/csv/action_cards.csv.example".format(BASE_DIR)
+
+    result = cli_runner.invoke(importcsv, [collection, csv_file])
+    assert (
+        "Collection {} does not support importcsv.".format(collection) in result.output
+    )
+
+
+def test_importcsv_no_drop(cli_runner, db, request):
+    collection = "actionCards"
+    csv_file = "{}/ressources/csv/action_cards.csv.example".format(BASE_DIR)
+
+    # Inserting an action card beforehand
+    action_card4 = ActionCardModel(
+        number=4,
+        title="action_card_title_4",
+        category="action_card_category_4",
+        type="action_card_type_4",
+        key="action_card_key_4",
+        sector="action_card_sector_4",
+        cost=4,
+    )
+    action_card4.save()
+
+    count = 0
+    with open(csv_file, "r") as fr:
+        reader = DictReader(fr)
+        for _ in reader:
+            count += 1
+
+    result = cli_runner.invoke(importcsv, [collection, csv_file])
+    assert (
+        "Successfully inserted {} objects in collection {}".format(count, collection)
+        in result.output
+    )
+    assert len(ActionCardModel.find_all()) == count + 1
+
+    def teardown():
+        ActionCardModel.drop_collection()
+
+    request.addfinalizer(teardown)
+
+
+def test_importcsv_with_drop(cli_runner, db, request):
+    collection = "actionCards"
+    csv_file = "{}/ressources/csv/action_cards.csv.example".format(BASE_DIR)
+
+    # Inserting an action card beforehand
+    action_card4 = ActionCardModel(
+        number=4,
+        title="action_card_title_4",
+        category="action_card_category_4",
+        type="action_card_type_4",
+        key="action_card_key_4",
+        sector="action_card_sector_4",
+        cost=4,
+    )
+    action_card4.save()
+
+    count = 0
+    with open(csv_file, "r") as fr:
+        reader = DictReader(fr)
+        for _ in reader:
+            count += 1
+
+    result = cli_runner.invoke(importcsv, ["--drop", collection, csv_file])
+    assert (
+        "Successfully inserted {} objects in collection {}".format(count, collection)
+        in result.output
+    )
+    assert len(ActionCardModel.find_all()) == count
+
+    def teardown():
+        ActionCardModel.drop_collection()
+
+    request.addfinalizer(teardown)


### PR DESCRIPTION
Adding the following CLI command to help us init data
```
$ flask importcsv --help
Usage: flask importcsv [OPTIONS] COLLECTION CSV_FILE

  Import a CSV file into a given collection

  COLLECTION is the name of the target mongo collection

  CSV_FILE is the path to the file

  CSV delimiter should be a comma and lines separeted by newline

Options:
  --drop / --no-drop  Whether to drop the collection beforehand or not
  --help              Show this message and exit.
```

CSV should be stored in `ressources/csv/` so that they are ignored by .gitignore